### PR TITLE
Update extensions for HTTPData-specific usage

### DIFF
--- a/Sources/SwiftMetrics/SwiftMetrics.swift
+++ b/Sources/SwiftMetrics/SwiftMetrics.swift
@@ -49,7 +49,7 @@ public struct InitData: SMData {
   public let data: [String:String]
 }
 
-private var swiftMon: SwiftMonitor?
+public var swiftMon: SwiftMonitor?
 
 
 private func receiveAgentCoreData(cSourceId: UnsafePointer<CChar>, cSize: CUnsignedInt, data: UnsafeMutableRawPointer) -> Void {

--- a/Sources/SwiftMetricsKitura/SwiftMetricsKitura.swift
+++ b/Sources/SwiftMetricsKitura/SwiftMetricsKitura.swift
@@ -62,6 +62,7 @@ private class HttpMonitor: ServerMonitor {
 public typealias httpClosure = (HTTPData) -> ()
 
 public extension SwiftMonitor.EventEmitter {
+
     static var httpObservers: [httpClosure] = []
 
     static func publish(data: HTTPData) {
@@ -73,6 +74,29 @@ public extension SwiftMonitor.EventEmitter {
     static func subscribe(callback: @escaping httpClosure) {
         httpObservers.append(callback)
     }
+
+}
+
+public extension SwiftMonitor {
+
+  public func on(_ callback: @escaping httpClosure) {
+    EventEmitter.subscribe(callback: callback)
+  }
+
+  func raiseEvent(data: HTTPData) {
+    EventEmitter.publish(data: data)
+  }
+
+}
+
+public extension SwiftMetrics {
+
+  public func emitData(_ data: HTTPData) {
+    if let monitor = swiftMon {
+      monitor.raiseEvent(data: data)
+    }
+  }
+
 }
 
 public class SwiftMetricsKitura {


### PR DESCRIPTION
Due to problems found in #10 extra methods are needed for the correct handling of new data structures. This creates the methods needed for HTTPData.