### PR TITLE
Remove force of MQTT to on in loader

### DIFF
--- a/Sources/SwiftMetrics/SwiftMetrics.swift
+++ b/Sources/SwiftMetrics/SwiftMetrics.swift
@@ -191,8 +191,6 @@ open class SwiftMetrics {
         self.setDefaultLibraryPath()
       }
       _ = loaderApi.initialize()
-      loaderApi.logMessage(debug, "start(): Forcing MQTT Connection on")
-      loaderApi.setProperty("com.ibm.diagnostics.healthcenter.mqtt", "on")
       loaderApi.start()
     } else {
       loaderApi.logMessage(fine, "start(): Swift Application Metrics has already started")


### PR DESCRIPTION
This will fix the problem from the SwiftMetrics side, but we still need a change to agentcore's properties file as it's default on there.