### PR TITLE
Bugfix: HTTP requests chart tooltips are wrong after resize

### DIFF
--- a/public/js/httpRequestsChart.js
+++ b/public/js/httpRequestsChart.js
@@ -98,22 +98,6 @@ var httpChartPlaceholder = httpChart.append("text")
     .style("font-size", "18px")
     .text("No Data Available");
 
-/*******************************************************************************
- * Copyright 2017 IBM Corp.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- ******************************************************************************/
-
 function updateHttpData(httpRequest) {
         httpRequestData = JSON.parse(httpRequest);
         if (httpRequestData == null) return;
@@ -224,5 +208,16 @@ function resizeHttpChart() {
             "translate(" + margin.left + "," + margin.top + ")")
         .attr("cx", function(d) { return http_xScale(d.time); })
         .attr("cy", function(d) { return http_yScale(d.longest); })
-        .append("svg:title").text(function(d) { return d.url; });
+        .append("svg:title").text(function(d) { // tooltip
+                    if(d.total === 1) {
+                        return d.url
+                    } else {
+                        return d.total
+                         + " requests\n average duration = "
+                         + d3.format(".2s")(d.average/1000)
+                         + "s\n longest duration = "
+                         +  d3.format(".2s")(d.longest/1000)
+                         + "s for URL: " + d.url;
+                    }
+                });
 }


### PR DESCRIPTION
Also removes an erroneous copyright header from half way down httpRequestsChart.js.