### PR TITLE
WIP/For Discussion: Improve logging and error handling

### DIFF
--- a/Sources/SwiftMetricsDash/SwiftMetricsDash.swift
+++ b/Sources/SwiftMetricsDash/SwiftMetricsDash.swift
@@ -25,6 +25,7 @@ import Foundation
 import Configuration
 import CloudFoundryConfig
 import Dispatch
+import LoggerAPI
 
 struct HTTPAggregateData: SMData {
   public var timeOfRequest: Int = 0
@@ -33,8 +34,17 @@ struct HTTPAggregateData: SMData {
   public var average: Double = 0
   public var total: Int = 0
 }
+
+
+enum SwiftMetricsDashError : Swift.Error {
+  case DirectoryNotFound(reason: String)
+}
+
 var router = Router()
 public class SwiftMetricsDash {
+
+
+
 
     var monitor:SwiftMonitor
     var SM:SwiftMetrics
@@ -89,7 +99,8 @@ public class SwiftMetricsDash {
         } else if fm.fileExists(atPath: packagesPath + "Packages/") { // Swift 3.0
           packagesPath.append("Packages/");
         } else {
-         print("SwiftMetricsDash: error finding install directory")
+          Log.error("SwiftMetricsDash: Unable to find install directory")
+          throw SwiftMetricsDashError.DirectoryNotFound(reason: "SwiftMetricsDash: Unable to find install directory");
         }
 
         do {
@@ -103,12 +114,12 @@ public class SwiftMetricsDash {
           print("SwiftMetricsDash: Error opening directory: \(packagesPath), \(error).")
           throw error
         }
-       
         router.all("/swiftmetrics-dash", middleware: StaticFileServer(path: packagesPath))
 
         if createServer {
             let configMgr = ConfigurationManager().load(.environmentVariables)
             Kitura.addHTTPServer(onPort: configMgr.port, with: router)
+            Log.info("SwiftMetricsDash : Starting on port \(configMgr.port)")
             print("SwiftMetricsDash : Starting on port \(configMgr.port)")
             Kitura.run()
         }

--- a/Sources/SwiftMetricsDash/SwiftMetricsDash.swift
+++ b/Sources/SwiftMetricsDash/SwiftMetricsDash.swift
@@ -41,11 +41,8 @@ enum SwiftMetricsDashError : Swift.Error {
 }
 
 var router = Router()
+
 public class SwiftMetricsDash {
-
-
-
-
     var monitor:SwiftMonitor
     var SM:SwiftMetrics
     var service:SwiftMetricsService


### PR DESCRIPTION
I think we need to catch and log every error when we do a `try` in Swift since Swift errors do not contain stack traces or anything useful to work out where the error came from.  I think we could also improve logging generally and do more of it. I'm wondering if it would make sense to use LoggerApi in all our classes instead of or as well as the agent-core logger and increase the logging a lot to help us diagnose bugs better in the future.  This PR is marked as 'work in progress' so that we can discuss how to implement logging in a standard way across SwiftMetrics