### PR TITLE
311 bluemix fix

### DIFF
--- a/Sources/SwiftMetricsDash/SwiftMetricsDash.swift
+++ b/Sources/SwiftMetricsDash/SwiftMetricsDash.swift
@@ -68,48 +68,8 @@ public class SwiftMetricsDash {
     }
 
     func startServer(router: Router) throws {
-        let fm = FileManager.default
-        let currentDir = fm.currentDirectoryPath
-        var workingPath = ""
-        if currentDir.contains(".build") {
-            //we're below the Packages directory
-            workingPath = currentDir
-        } else {
-         	//we're above the Packages directory
-            workingPath = CommandLine.arguments[0]
-        }
-        let i = workingPath.range(of: ".build")
-        var packagesPath = ""
-        if i == nil {
-            // we could be in bluemix
-            packagesPath="/home/vcap/app/"
-        } else {
-            packagesPath = workingPath.substring(to: i!.lowerBound)
-        }
-
-        // Swift 3.1
-        let checkoutsPath = packagesPath + ".build/checkouts/"
-        if fm.fileExists(atPath: checkoutsPath) {
-           packagesPath = checkoutsPath;
-        } else if fm.fileExists(atPath: packagesPath + "Packages/") { // Swift 3.0
-          packagesPath.append("Packages/");
-        } else {
-         print("SwiftMetricsDash: error finding install directory")
-        }
-
-        do {
-          let dirContents = try fm.contentsOfDirectory(atPath: packagesPath)
-          for dir in dirContents {
-            if dir.contains("SwiftMetrics") {
-                packagesPath.append("\(dir)/public")
-            }
-          }
-        } catch {
-          print("SwiftMetricsDash: Error opening directory: \(packagesPath), \(error).")
-          throw error
-        }
-       
-        router.all("/swiftmetrics-dash", middleware: StaticFileServer(path: packagesPath))
+        print("SwiftMetricsDash: Attempting to host middleware located at \(self.SM.localSourceDirectory)/public")
+        router.all("/swiftmetrics-dash", middleware: StaticFileServer(path: self.SM.localSourceDirectory + "/public"))
 
         if self.createServer {
             let configMgr = ConfigurationManager().load(.environmentVariables)

--- a/Sources/SwiftMetricsDash/SwiftMetricsDash.swift
+++ b/Sources/SwiftMetricsDash/SwiftMetricsDash.swift
@@ -68,7 +68,6 @@ public class SwiftMetricsDash {
     }
 
     func startServer(router: Router) throws {
-        print("SwiftMetricsDash: Attempting to host middleware located at \(self.SM.localSourceDirectory)/public")
         router.all("/swiftmetrics-dash", middleware: StaticFileServer(path: self.SM.localSourceDirectory + "/public"))
 
         if self.createServer {


### PR DESCRIPTION
In the end, it was adding a / onto the end of the Bluemix Path that fixed it, but I also moved the path finding logic from loadProperties() into init() and used it to populate a new localSourceDirectory instance variable. This can then be used in loadProperties() and in SwiftMetricsDash.startServer() so we don't have the duplicate path-finding code.

Partly fixes issue #108 , needs to push with the swift-buildpack fix.
`cf push -b https://github.com/IBM-Swift/swift-buildpack.git#issue.cache <appName>`