### PR TITLE
Draw http request in correct order

### DIFF
--- a/public/js/httpRequestsChart.js
+++ b/public/js/httpRequestsChart.js
@@ -100,14 +100,14 @@ var httpChartPlaceholder = httpChart.append("text")
 
 function updateHttpData(httpRequest) {
         httpRequestData = JSON.parse(httpRequest);
-        if (httpRequestData == null) return;
+        if (!httpRequestData) return;
+       
+        var httpLength = httpData.length;
 
         // Send data to throughput chart so as not to duplicate requests
         updateThroughPutData(httpRequestData)
-
-        if (!httpRequestData) return;
-
-        if(httpData.length === 0) {
+   
+        if (httpLength === 0) {
             // first data - remove "No Data Available" label
             httpChartPlaceholder.attr("visibility", "hidden");
         }
@@ -117,7 +117,17 @@ function updateHttpData(httpRequest) {
         httpRequestData.time = parseInt(httpRequestData.time)
         httpRequestData.total = parseInt(httpRequestData.total)
 
-        httpData.push(httpRequestData);
+        // Check to see if the request started before previous request(s)
+        if (httpLength > 0 && (httpRequestData.time < httpData[httpLength-1].time)) {
+            var i = httpLength - 1;
+            while (httpRequestData.time < httpData[i].time) {
+                i--;
+            }
+            // Insert the data into the right place            
+            httpData.splice(i+1, 0, httpRequestData);
+        } else {
+            httpData.push(httpRequestData);
+        }
 
         // Only keep 30 minutes or 2000 items of data
         var currentTime = Date.now()


### PR DESCRIPTION
We plot our http requests in the order that they are stored in an array. We were always adding data to the end of the array, as each request ends but if a request started earlier than one that finished later, this would mean that we plot them incorrectly.

I now check the request time against the last one in the array and if it is earlier, find the correct place and insert it there.

Fixes #100