### PR TITLE
WIP: Update travis config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,14 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      env: SWIFT_VERSION=3.1.1
+      env: SWIFT_SNAPSHOT=3.1.1
     - os: osx
       osx_image: xcode8.2
       sudo: required
     - os: osx
       osx_image: xcode8.3
       sudo: required
-      env: SWIFT_VERSION=3.1.1
+      env: SWIFT_SNAPSHOT=3.1.1
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,14 +18,14 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      env: SWIFT_SNAPSHOT=3.1.1
+      env: SWIFT_VERSION=3.1.1
     - os: osx
       osx_image: xcode8.2
       sudo: required
     - os: osx
-      osx_image: xcode8.2
+      osx_image: xcode8.3
       sudo: required
-      env: SWIFT_SNAPSHOT=3.1.1
+      env: SWIFT_VERSION=3.1.1
 
 before_install:
   - git clone https://github.com/IBM-Swift/Package-Builder.git


### PR DESCRIPTION
Seeing a build failure on Travis on 3.1.1 with SwiftyJSON, which is a dependency of Kitura.  Updating Xcode to 8.3 to match the same version as Kitura seems to fix this.