### PR TITLE
Give SwiftMetrics its SwiftyJSON dependency rather than relying on Kituras

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,13 +37,14 @@ let package = Package(
     .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "1.7.0"),
     .package(url: "https://github.com/IBM-Swift/Kitura-WebSocket.git", from: "0.9.0"),
     .package(url: "https://github.com/IBM-Swift/Kitura-Request.git", from: "0.8.0"),
-    .package(url: "https://github.com/IBM-Swift/Swift-cfenv.git", from: "4.0.0")
+    .package(url: "https://github.com/IBM-Swift/Swift-cfenv.git", from: "4.0.0"),
+    .package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", from: "17.0.0"),
   ],
   targets: [
       .target(name: "SwiftMetrics", dependencies: ["agentcore", "hcapiplugin", "envplugin", "cpuplugin", "memplugin", "CloudFoundryEnv"]),
       .target(name: "SwiftMetricsKitura", dependencies: ["SwiftMetrics", "Kitura"]),
       .target(name: "SwiftBAMDC", dependencies: ["SwiftMetricsKitura", "KituraRequest", "Kitura-WebSocket"]),
-      .target(name: "SwiftMetricsBluemix", dependencies: ["SwiftMetricsKitura","SwiftBAMDC"]),
+      .target(name: "SwiftMetricsBluemix", dependencies: ["SwiftMetricsKitura","SwiftBAMDC","SwiftyJSON"]),
       .target(name: "SwiftMetricsDash", dependencies: ["SwiftMetricsBluemix"]),
       .target(name: "SwiftMetricsPrometheus", dependencies:["SwiftMetricsKitura"]),
       .target(name: "SwiftMetricsCommonSample", dependencies: ["SwiftMetrics"],


### PR DESCRIPTION
Kitura 2.x is removing its dependency on SwiftyJSON, however SwiftMetricsBluemix still needs it.

As a short term solution this adds a dependency on SwiftyJSON directly from SwiftMetrics. Longer term SwiftMetricsBluemix should switch to using Codable for Swift 4.x and later.