### PR TITLE
Deliver IBM Cloud crash fix without requiring Swift-cfenv upgrade

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
     .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.0.0"),
     .package(url: "https://github.com/IBM-Swift/Kitura-WebSocket.git", from: "0.9.0"),
     .package(url: "https://github.com/IBM-Swift/Kitura-Request.git", from: "0.8.0"),
-    .package(url: "https://github.com/IBM-Swift/Swift-cfenv.git", from: "6.0.0"),
+    .package(url: "https://github.com/IBM-Swift/Swift-cfenv.git", from: "4.0.0"),
     .package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", from: "17.0.0"),
   ],
   targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
     .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.0.0"),
     .package(url: "https://github.com/IBM-Swift/Kitura-WebSocket.git", from: "0.9.0"),
     .package(url: "https://github.com/IBM-Swift/Kitura-Request.git", from: "0.8.0"),
-    .package(url: "https://github.com/IBM-Swift/Swift-cfenv.git", from: "4.0.0"),
+    .package(url: "https://github.com/IBM-Swift/Swift-cfenv.git", from: "6.0.0"),
     .package(url: "https://github.com/IBM-Swift/SwiftyJSON.git", from: "17.0.0"),
   ],
   targets: [

--- a/README.md
+++ b/README.md
@@ -281,9 +281,10 @@ This project uses a semver-parsable X.0.Z version number for releases, where X i
 Non-release versions of this project (for example on github.com/RuntimeTools/SwiftMetrics) will use semver-parsable X.0.Z-dev.B version numbers, where X.0.Z is the last release with Z incremented and B is an integer. For further information on the development process go to the  [SwiftMetrics wiki][1]: [Developing](https://github.com/RuntimeTools/SwiftMetrics/wiki/Developing).
 
 ## Version
-2.0.2
+2.0.3
 
 ## Release History
+`2.0.3` - Provide crash fix without Swift-cfenv version change
 `2.0.2` - Fix crash when deployed to IBM cloud.  
 `2.0.1` - Minor fixes.  
 `2.0.0` - Dependency update to use Kitura 2  

--- a/README.md
+++ b/README.md
@@ -281,9 +281,10 @@ This project uses a semver-parsable X.0.Z version number for releases, where X i
 Non-release versions of this project (for example on github.com/RuntimeTools/SwiftMetrics) will use semver-parsable X.0.Z-dev.B version numbers, where X.0.Z is the last release with Z incremented and B is an integer. For further information on the development process go to the  [SwiftMetrics wiki][1]: [Developing](https://github.com/RuntimeTools/SwiftMetrics/wiki/Developing).
 
 ## Version
-2.0.3
+2.0.4
 
 ## Release History
+`2.0.4` - Reapply Swift-cfenv version change
 `2.0.3` - Provide crash fix without Swift-cfenv version change
 `2.0.2` - Fix crash when deployed to IBM cloud.  
 `2.0.1` - Minor fixes.  


### PR DESCRIPTION
The present `2.0.2` release of SwiftMetrics introduces both a fix for a high impact crash on IBM Cloud with Swift 4 *and* a major version change to the Swift-cfenv dependency.

This means that in order for a user of Kitura with CloudEnvironment (a common configuration) to get the crash fix, they would need to be on CloudEnvironment 6 (it has a dependency on Swift-cfenv). In order to ensure even those using CloudEnvironment 4 get the crash fix this PR introduces 2 new commits intended to be released as `2.0.3` and `2.0.4`.

`2.0.3` will provide the crash fix but without the Swift-cfenv 6 requirement, so anyone with that configuration will automatically receive the fix on their next `swift update`.
`2.0.4` will provide Swift-cfenv at version 6 still so that anyone who currently has SwiftMetrics `2.0.2` and Swift-cfenv 6 will not be broken and will move from `2.0.2` to `2.0.4` on their next `swift update`.

Ideally we would have at least have bumped the SwiftMetrics minor version when upping the major version of Swift-cfenv, but since that has already happened and there may be people using this configuration it is probably best not to remove Swift-cfenv from `2.0.x` now.