### PR TITLE
Revert "Use Encodable to JSON serialize objects in SwiftMetricsDash instead of SwiftyJSON"

### DIFF
--- a/Sources/SwiftMetrics/SwiftMetrics.swift
+++ b/Sources/SwiftMetrics/SwiftMetrics.swift
@@ -24,19 +24,13 @@ import Glibc
 import Darwin
 #endif
 
-public protocol SMData: Encodable {
+public protocol SMData {
 }
 
 public struct CPUData: SMData {
   public let timeOfSample: Int
   public let percentUsedByApplication: Float
   public let percentUsedBySystem: Float
-
-  enum CodingKeys: String, CodingKey {
-    case timeOfSample = "time"
-    case percentUsedByApplication = "process"
-    case percentUsedBySystem = "system"
-  }
 }
 
 public struct MemData: SMData {
@@ -47,12 +41,6 @@ public struct MemData: SMData {
   public let applicationAddressSpaceSize: Int
   public let applicationPrivateSize: Int
   public let applicationRAMUsed: Int
-
-  enum CodingKeys: String, CodingKey {
-    case timeOfSample = "time"
-    case applicationRAMUsed = "physical"
-    case totalRAMUsed = "physical_used"
-  }
 }
 
 public struct EnvData: SMData {
@@ -468,3 +456,4 @@ private func executableFolderURL() -> URL {
     return swiftMon!
   }
 }
+

--- a/Sources/SwiftMetricsDash/SwiftMetricsDash.swift
+++ b/Sources/SwiftMetricsDash/SwiftMetricsDash.swift
@@ -18,6 +18,7 @@ import Kitura
 import SwiftMetricsKitura
 import SwiftMetricsBluemix
 import SwiftMetrics
+import SwiftyJSON
 import KituraNet
 import KituraWebSocket
 import Foundation
@@ -26,18 +27,12 @@ import CloudFoundryEnv
 import Dispatch
 
 struct HTTPAggregateData: SMData {
-  public var time: Int = 0
+  public var timeOfRequest: Int = 0
   public var url: String = ""
   public var longest: Double = 0
   public var average: Double = 0
   public var total: Int = 0
 }
-
-struct DashData<T: Encodable>: Encodable {
-  public let topic: String
-  public let payload: T
-}
-
 var router = Router()
 public class SwiftMetricsDash {
 
@@ -74,7 +69,7 @@ public class SwiftMetricsDash {
 
     func startServer(router: Router) throws {
       router.all("/swiftmetrics-dash", middleware: StaticFileServer(path: self.SM.localSourceDirectory + "/public"))
-
+      
         if self.createServer {
             let configMgr = ConfigurationManager().load(.environmentVariables)
             Kitura.addHTTPServer(onPort: configMgr.port, with: router)
@@ -92,7 +87,6 @@ class SwiftMetricsService: WebSocketService {
     let httpQueue = DispatchQueue(label: "httpStoreQueue")
     let jobsQueue = DispatchQueue(label: "jobsQueue")
     var monitor:SwiftMonitor
-    let encoder = JSONEncoder()
 
 
     public init(monitor: SwiftMonitor) {
@@ -104,23 +98,31 @@ class SwiftMetricsService: WebSocketService {
     }
 
 
+
     func sendCPU(cpu: CPUData) {
-        let cpuDashData = DashData(topic: "cpu", payload: cpu)
-        let data = try! encoder.encode(cpuDashData)
+        let cpuLine = JSON(["topic":"cpu", "payload":["time":"\(cpu.timeOfSample)","process":"\(cpu.percentUsedByApplication)","system":"\(cpu.percentUsedBySystem)"]])
 
         for (_,connection) in connections {
-          connection.send(message: String(data: data, encoding: .utf8)!)
+            if let messageToSend = cpuLine.rawString() {
+                connection.send(message: messageToSend)
+            }
         }
 
     }
 
 
     func sendMEM(mem: MemData) {
-        let memDashData = DashData(topic: "memory", payload: mem)
-        let data = try! encoder.encode(memDashData)
+
+        let memLine = JSON(["topic":"memory","payload":[
+                "time":"\(mem.timeOfSample)",
+                "physical":"\(mem.applicationRAMUsed)",
+                "physical_used":"\(mem.totalRAMUsed)"
+                ]])
 
         for (_,connection) in connections {
-          connection.send(message: String(data: data, encoding: .utf8)!)
+            if let messageToSend = memLine.rawString() {
+                connection.send(message: messageToSend)
+            }
         }
     }
 
@@ -164,26 +166,32 @@ class SwiftMetricsService: WebSocketService {
              }
         }
 
-        let envArray = [["Parameter":"Command Line","Value":"\(commandLine)"],
-                    ["Parameter":"Hostname","Value":"\(hostname)"],
-                    ["Parameter":"Number of Processors","Value":"\(numPar)"],
-                    ["Parameter":"OS Architecture","Value":"\(os)"]]
 
-        let envDashData = DashData(topic: "env", payload: envArray)
-        let data = try! encoder.encode(envDashData)
+        let envLine = JSON(["topic":"env","payload":[
+                ["Parameter":"Command Line","Value":"\(commandLine)"],
+                ["Parameter":"Hostname","Value":"\(hostname)"],
+                ["Parameter":"Number of Processors","Value":"\(numPar)"],
+                ["Parameter":"OS Architecture","Value":"\(os)"]
+                ]])
 
         for (_,connection) in connections {
-            connection.send(message: String(data: data, encoding: .utf8)!)
+            if let messageToSend = envLine.rawString() {
+                connection.send(message: messageToSend)
+            }
         }
     }
 
 
     public func sendTitle()  {
-        let titleLine = "{\"topic\":\"title\",\"payload\":{\"title\":\"Application Metrics for Swift\",\"docs\": \"http://github.com/RuntimeTools/SwiftMetrics\"}}"
+        let titleLine = JSON(["topic":"title","payload":[
+            "title":"Application Metrics for Swift",
+            "docs": "http://github.com/RuntimeTools/SwiftMetrics"]])
 
          for (_,connection) in connections {
-             connection.send(message: titleLine)
-         }
+            if let messageToSend = titleLine.rawString() {
+                connection.send(message: messageToSend)
+            }
+        }
     }
 
     public func storeHTTP(myhttp: HTTPData) {
@@ -191,7 +199,7 @@ class SwiftMetricsService: WebSocketService {
     	  httpQueue.sync {
             if self.httpAggregateData.total == 0 {
                 self.httpAggregateData.total = 1
-                self.httpAggregateData.time = localmyhttp.timeOfRequest
+                self.httpAggregateData.timeOfRequest = localmyhttp.timeOfRequest
                 self.httpAggregateData.url = localmyhttp.url
                 self.httpAggregateData.longest = localmyhttp.duration
                 self.httpAggregateData.average = localmyhttp.duration
@@ -223,20 +231,34 @@ class SwiftMetricsService: WebSocketService {
         httpQueue.sync {
             let localCopy = self.httpAggregateData
             if localCopy.total > 0 {
-                let httpDashData = DashData(topic: "http", payload: localCopy)
-                let data = try! encoder.encode(httpDashData)
+                let httpLine = JSON([
+                "topic":"http","payload":[
+                    "time":"\(localCopy.timeOfRequest)",
+                    "url":"\(localCopy.url)",
+                    "longest":"\(localCopy.longest)",
+                    "average":"\(localCopy.average)",
+                    "total":"\(localCopy.total)"]])
 
                 for (_,connection) in self.connections {
-                    connection.send(message: String(data: data, encoding: .utf8)!)
+                    if let messageToSend = httpLine.rawString() {
+                        connection.send(message: messageToSend)
+                    }
                 }
                 self.httpAggregateData = HTTPAggregateData()
             }
         }
         httpURLsQueue.sync {
-            var messageToSend:String = ""
+            var responseData:[JSON] = []
             let localCopy = self.httpURLData
             for (key, value) in localCopy {
-                  messageToSend = messageToSend + "{\"url\":\"" + key + "\", \"averageResponseTime\": " + String(value.0) + "},"
+                let json = JSON(["url":key, "averageResponseTime": value.0])
+                    responseData.append(json)
+            }
+            var messageToSend:String=""
+
+            // build up the messageToSend string
+            for response in responseData {
+                messageToSend += response.rawString()! + ","
             }
 
             if !messageToSend.isEmpty {

--- a/Sources/SwiftMetricsKitura/SwiftMetricsKitura.swift
+++ b/Sources/SwiftMetricsKitura/SwiftMetricsKitura.swift
@@ -23,7 +23,7 @@ public struct HTTPData: SMData {
   public let timeOfRequest: Int
   public let url: String
   public let duration: Double
-  public let statusCode: Int?
+  public let statusCode: HTTPStatusCode?
   public let requestMethod: String
 }
 
@@ -73,7 +73,7 @@ private class HttpMonitor: ServerMonitor {
                         self.sM.emitData(HTTPData(timeOfRequest:Int(req.requestTime),
                              url:req.request.urlURL.absoluteString,
                              duration:(self.timeIntervalSince1970MilliSeconds - req.requestTime),
-                             statusCode:response.statusCode?.rawValue, requestMethod:req.request.method))
+                             statusCode:response.statusCode, requestMethod:req.request.method))
                         requestStore.remove(at:index)
                         break
                        }

--- a/Sources/SwiftMetricsPrometheus/SwiftMetricsPrometheus.swift
+++ b/Sources/SwiftMetricsPrometheus/SwiftMetricsPrometheus.swift
@@ -110,11 +110,11 @@ public class HTTPDurationSummary {
 
 public class HTTPCounterHandler {
     let handler: String
-    let statusCode: Int
+    let statusCode: HTTPStatusCode
     let requestMethod: String
     var count: Int = 0
 
-    public init(handler: String, statusCode: Int, requestMethod: String) {
+    public init(handler: String, statusCode: HTTPStatusCode, requestMethod: String) {
         self.handler = handler
         self.statusCode = statusCode
         self.requestMethod = requestMethod.lowercased()
@@ -132,7 +132,7 @@ public class HTTPCounter {
     public init() {
     }
 
-    public func addRequest(url: String, statusCode: Int, requestMethod: String) {
+    public func addRequest(url: String, statusCode: HTTPStatusCode, requestMethod: String) {
 
         if let urlparser = URL(string: url) {
             let path = urlparser.path
@@ -169,7 +169,7 @@ func memEvent(mem: MemData) {
 }
 
 func httpEvent(http: HTTPData) {
-    let statusCode = http.statusCode ?? HTTPStatusCode.unknown.rawValue
+    let statusCode = http.statusCode ?? HTTPStatusCode.unknown
     httpCounter.addRequest(url: http.url, statusCode: statusCode, requestMethod: http.requestMethod);
     httpDurations.addRequest(url: http.url, durationMicros: http.duration * 1000.0);
 
@@ -243,7 +243,7 @@ public class SwiftMetricsPrometheus {
                 .send("# TYPE http_requests_total counter\n")
 
             httpCounter.writeCounts( writer: {(handler: HTTPCounterHandler)->() in
-                response.send("http_requests_total{code=\"\(handler.statusCode)\", handler=\"\(handler.handler)\", method=\"\(handler.requestMethod)\"} \(handler.count)\n")
+                response.send("http_requests_total{code=\"\(handler.statusCode.rawValue)\", handler=\"\(handler.handler)\", method=\"\(handler.requestMethod)\"} \(handler.count)\n")
             } )
             response
                 .send("# HELP http_request_duration_microseconds The HTTP request latencies in microseconds.\n")


### PR DESCRIPTION
Reverts RuntimeTools/SwiftMetrics#174 for the time being due to clash with #177