### PR TITLE
Widen version range for Kitura dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
         .executable(name: "SwiftMetricsCommonSample", targets: ["SwiftMetricsCommonSample"]),
     ],
   dependencies: [
-    .package(url: "https://github.com/IBM-Swift/Kitura.git", .upToNextMinor(from: "2.1.0")),
+    .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.1.0"),
     .package(url: "https://github.com/IBM-Swift/Kitura-WebSocket.git", from: "1.0.0"),
     .package(url: "https://github.com/IBM-Swift/SwiftyRequest.git", from: "1.0.0"),
     .package(url: "https://github.com/IBM-Swift/Swift-cfenv.git", from: "6.0.0"),


### PR DESCRIPTION
The version range of the SwiftMetrics dependency on Kitura got narrowed in to minor and now Kitura `2.2.0` is not resolving properly with SwiftMetrics `2.x`.

I don't see any reason not to widen the version range, provided the minimum version remains `2.1.0`.