### PR TITLE
Remove spurious error messages

### DIFF
--- a/Sources/SwiftMetrics/SwiftMetrics.swift
+++ b/Sources/SwiftMetrics/SwiftMetrics.swift
@@ -114,8 +114,6 @@ open class SwiftMetrics {
       }
       if let i = workingPath.range(of: ".build") {
         applicationPath = String(workingPath[..<i.lowerBound])
-      } else {
-        print("SwiftMetrics: Error finding .build directory")
       }
     } else {
       // We're in Bluemix, use the path the swift-buildpack saves libraries to
@@ -130,8 +128,6 @@ open class SwiftMetrics {
       let packagesPath = applicationPath + "Packages/"
       if fm.fileExists(atPath: packagesPath) {
         _ = fm.changeCurrentDirectoryPath(packagesPath)
-      } else {
-        print("SwiftMetrics: Error finding directory containing source code in \(applicationPath)")
       }
     }
     do {
@@ -456,4 +452,3 @@ private func executableFolderURL() -> URL {
     return swiftMon!
   }
 }
-


### PR DESCRIPTION
These error messages are occurring in normal operation where SwiftMetrics is working fine and they are causing confusion for users.  @tobespc it would be good to get this in for 2.4.0, it's a non-functional change so shouldn't cause any issues.

Fixes #181 