### PR TITLE
 Remove JSON manipulation from SwiftMetricsDash Fixes #185

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,7 +2,7 @@
 Authors ordered by first contribution:
 
  - Matt Colegate (https://github.com/mattcolegate)
- - Ian Partridge (https://github.com/ianpartridge) 
+ - Ian Partridge (https://github.com/ianpartridge)
  - Toby Corbin (https://github.com/tobespc)
  - Julie Stalley (https://github.com/stalleyj)
  - Navneet Gupta (https://github.com/na-gupta)
@@ -10,3 +10,4 @@ Authors ordered by first contribution:
  - qibobo (https://github.com/qibobo)  
  - Sian January (https://github.com/sjanuary)
  - Kye Maloy (https://github.com/kyemaloy97)
+ - Jonathan Spruce (https://github.com/jonathan-spruce)

--- a/Tests/SwiftMetricsTests/SwiftMetricsTests.swift
+++ b/Tests/SwiftMetricsTests/SwiftMetricsTests.swift
@@ -61,7 +61,7 @@ class SwiftMetricsTests: XCTestCase {
 
         monitoring!.on(processCPU)
 
-        waitForExpectations(timeout: 30) { error in
+        waitForExpectations(timeout: 10) { error in
             XCTAssertNil(error)
         }
     }
@@ -82,7 +82,7 @@ class SwiftMetricsTests: XCTestCase {
 
         monitoring!.on(processInit)
 
-        waitForExpectations(timeout: 30) { error in
+        waitForExpectations(timeout: 10) { error in
             XCTAssertNil(error)
         }
     }
@@ -103,7 +103,7 @@ class SwiftMetricsTests: XCTestCase {
 
         monitoring!.on(processEnv)
 
-        waitForExpectations(timeout: 30) { error in
+        waitForExpectations(timeout: 10) { error in
             XCTAssertNil(error)
         }
     }
@@ -131,7 +131,7 @@ class SwiftMetricsTests: XCTestCase {
 
         monitoring!.on(processMem)
 
-        waitForExpectations(timeout: 30) { error in
+        waitForExpectations(timeout: 10) { error in
             XCTAssertNil(error)
         }
     }
@@ -152,7 +152,7 @@ class SwiftMetricsTests: XCTestCase {
        }
 
        monitoring!.on(processLatency)
-       waitForExpectations(timeout: 30) { error in
+       waitForExpectations(timeout: 10) { error in
           XCTAssertNil(error)
        }
    }
@@ -172,7 +172,7 @@ class SwiftMetricsTests: XCTestCase {
         monitoring = sm!.monitor()
 
         monitoring!.on(processCPU)
-        waitForExpectations(timeout: 30) { error in
+        waitForExpectations(timeout: 10) { error in
             XCTAssertNil(error)
         }
     }

--- a/Tests/SwiftMetricsTests/SwiftMetricsTests.swift
+++ b/Tests/SwiftMetricsTests/SwiftMetricsTests.swift
@@ -61,7 +61,7 @@ class SwiftMetricsTests: XCTestCase {
 
         monitoring!.on(processCPU)
 
-        waitForExpectations(timeout: 10) { error in
+        waitForExpectations(timeout: 30) { error in
             XCTAssertNil(error)
         }
     }
@@ -82,7 +82,7 @@ class SwiftMetricsTests: XCTestCase {
 
         monitoring!.on(processInit)
 
-        waitForExpectations(timeout: 10) { error in
+        waitForExpectations(timeout: 30) { error in
             XCTAssertNil(error)
         }
     }
@@ -103,7 +103,7 @@ class SwiftMetricsTests: XCTestCase {
 
         monitoring!.on(processEnv)
 
-        waitForExpectations(timeout: 10) { error in
+        waitForExpectations(timeout: 30) { error in
             XCTAssertNil(error)
         }
     }
@@ -131,7 +131,7 @@ class SwiftMetricsTests: XCTestCase {
 
         monitoring!.on(processMem)
 
-        waitForExpectations(timeout: 10) { error in
+        waitForExpectations(timeout: 30) { error in
             XCTAssertNil(error)
         }
     }
@@ -152,7 +152,7 @@ class SwiftMetricsTests: XCTestCase {
        }
 
        monitoring!.on(processLatency)
-       waitForExpectations(timeout: 10) { error in
+       waitForExpectations(timeout: 30) { error in
           XCTAssertNil(error)
        }
    }
@@ -172,7 +172,7 @@ class SwiftMetricsTests: XCTestCase {
         monitoring = sm!.monitor()
 
         monitoring!.on(processCPU)
-        waitForExpectations(timeout: 10) { error in
+        waitForExpectations(timeout: 30) { error in
             XCTAssertNil(error)
         }
     }


### PR DESCRIPTION
Removes the JSON used in the SwiftMetricsDash, which was causing a memory leak in Swift 4.1.2.