### PR TITLE
Add the method to the data we return to the dashboard and the REST API

### DIFF
--- a/Sources/SwiftMetricsDash/SwiftMetricsDash.swift
+++ b/Sources/SwiftMetricsDash/SwiftMetricsDash.swift
@@ -226,6 +226,7 @@ class SwiftMetricsService: WebSocketService {
 
     public func storeHTTP(myhttp: HTTPData) {
         let localmyhttp = myhttp
+        let urlWithVerb = localmyhttp.requestMethod + " " + localmyhttp.url
         httpQueue.sync {
             if self.httpAggregateData.total == 0 {
                 self.httpAggregateData.total = 1
@@ -245,7 +246,7 @@ class SwiftMetricsService: WebSocketService {
             }
         }
         httpURLsQueue.async {
-            let urlTuple = self.httpURLData[localmyhttp.url]
+            let urlTuple = self.httpURLData[urlWithVerb]
             if(urlTuple != nil) {
                 let averageResponseTime = urlTuple!.0
                 let hits = urlTuple!.1
@@ -254,9 +255,9 @@ class SwiftMetricsService: WebSocketService {
                     longest = localmyhttp.duration
                 }
                 // Recalculate the average
-                self.httpURLData.updateValue(((averageResponseTime * hits + localmyhttp.duration)/(hits + 1), hits + 1, longest), forKey: localmyhttp.url)
+                self.httpURLData.updateValue(((averageResponseTime * hits + localmyhttp.duration)/(hits + 1), hits + 1, longest), forKey: urlWithVerb)
             } else {
-                self.httpURLData.updateValue((localmyhttp.duration, 1, localmyhttp.duration), forKey: localmyhttp.url)
+                self.httpURLData.updateValue((localmyhttp.duration, 1, localmyhttp.duration), forKey: urlWithVerb)
             }
         }
     }

--- a/Sources/SwiftMetricsREST/SwiftMetricsREST.swift
+++ b/Sources/SwiftMetricsREST/SwiftMetricsREST.swift
@@ -37,6 +37,7 @@ import Configuration
 
     public struct HttpUrlReport: Codable {
       let url: String
+      let method: String
       var hits: Int = 0
       var averageResponseTime: Double = 0.0
       var longestResponseTime: Double = 0.0
@@ -160,7 +161,7 @@ public class SwiftMetricsREST {
         guard var temp_httpUrlReports = smrCollectionList[key]?.collection.httpUrls else {
           continue;
         }
-        if let index = temp_httpUrlReports.index(where: { $0.url == http.url })  {
+        if let index = temp_httpUrlReports.index(where: { $0.url == http.url && $0.method == http.requestMethod})  {
           temp_httpUrlReports[index].hits += 1
           if (http.duration > temp_httpUrlReports[index].longestResponseTime ) {
             temp_httpUrlReports[index].longestResponseTime = http.duration
@@ -168,7 +169,7 @@ public class SwiftMetricsREST {
           temp_httpUrlReports[index].averageResponseTime = ((temp_httpUrlReports[index].averageResponseTime * Double(temp_httpUrlReports[index].hits - 1)) + http.duration) / Double(temp_httpUrlReports[index].hits)
         } else {
           // if index is nil, then the url wasn't found - add it
-          temp_httpUrlReports.append(HttpUrlReport(url: http.url, hits: 1, averageResponseTime: http.duration, longestResponseTime: http.duration))
+          temp_httpUrlReports.append(HttpUrlReport(url: http.url, method: http.requestMethod, hits: 1, averageResponseTime: http.duration, longestResponseTime: http.duration))
         }
         smrCollectionList[key]!.collection.httpUrls = temp_httpUrlReports
       }


### PR DESCRIPTION
This adds the http method to the dashboard and the REST API.
This is similar to the change that went into appmetrics for the summary table:
RuntimeTools/appmetrics-dash#153
and the REST API:
RuntimeTools/appmetrics-dash#155