### PR TITLE
chore: update SwiftyRequest to v2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.3.0"),
     webSocketPackage,
-    .package(url: "https://github.com/IBM-Swift/SwiftyRequest.git", from: "1.0.0"),
+    .package(url: "https://github.com/IBM-Swift/SwiftyRequest.git", from: "2.0.0"),
     .package(url: "https://github.com/IBM-Swift/Swift-cfenv.git", from: "6.0.0"),
     .package(url: "https://github.com/RuntimeTools/omr-agentcore", .exact("3.2.4-swift4")),
   ],

--- a/Package@swift-4.0.swift
+++ b/Package@swift-4.0.swift
@@ -45,7 +45,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.3.0"),
     webSocketPackage,
-    .package(url: "https://github.com/IBM-Swift/SwiftyRequest.git", from: "1.0.0"),
+    .package(url: "https://github.com/IBM-Swift/SwiftyRequest.git", from: "2.0.0"),
     .package(url: "https://github.com/IBM-Swift/Swift-cfenv.git", from: "6.0.0"),
     .package(url: "https://github.com/RuntimeTools/omr-agentcore", .exact("3.2.4-swift4")),
   ],

--- a/Package@swift-4.1.swift
+++ b/Package@swift-4.1.swift
@@ -45,7 +45,7 @@ let package = Package(
   dependencies: [
     .package(url: "https://github.com/IBM-Swift/Kitura.git", from: "2.3.0"),
     webSocketPackage,
-    .package(url: "https://github.com/IBM-Swift/SwiftyRequest.git", from: "1.0.0"),
+    .package(url: "https://github.com/IBM-Swift/SwiftyRequest.git", from: "2.0.0"),
     .package(url: "https://github.com/IBM-Swift/Swift-cfenv.git", from: "6.0.0"),
     .package(url: "https://github.com/RuntimeTools/omr-agentcore", .exact("3.2.4-swift4")),
   ],


### PR DESCRIPTION
Allow Kitura users to take advantage of SwiftyRequest v2 by upgrading the dependency in SwiftMetrics.