### PR TITLE
fix: Linux testing on Swift 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
       sudo: required
       env: SWIFT_SNAPSHOT=4.2.4
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
     - os: linux
       dist: xenial

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ matrix:
       sudo: required
       env: SWIFT_SNAPSHOT=4.1.3
     - os: linux
-      dist: xenial
+      dist: trusty
       sudo: required
       env: SWIFT_SNAPSHOT=4.2.4
     - os: linux
       dist: xenial
       sudo: required
     - os: linux
-      dist: xenial
+      dist: trusty
       sudo: required
       env: SWIFT_SNAPSHOT=4.2.4 KITURA_NIO=1
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ matrix:
       sudo: required
       env: SWIFT_SNAPSHOT=4.1.3
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       env: SWIFT_SNAPSHOT=4.2.4
     - os: linux
       dist: trusty
       sudo: required
     - os: linux
-      dist: trusty
+      dist: xenial
       sudo: required
       env: SWIFT_SNAPSHOT=4.2.4 KITURA_NIO=1
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,9 @@ matrix:
       dist: trusty
       sudo: required
       env: SWIFT_SNAPSHOT=4.2.4
-    - os: linux
-      dist: xenial
-      sudo: required
+#    - os: linux
+#      dist: xenial
+#      sudo: required
     - os: linux
       dist: trusty
       sudo: required


### PR DESCRIPTION
Currently, testing on Swift 5 is failing because it tries to install some system packages that don't exist on Ubuntu 14.04.

As Swift 5 on 14.04 is an unimportant combination, instead we move the Swift 5 testing to run on 16.04 instead.