### PR TITLE
Fix: REST-API README formatting

### DIFF
--- a/REST-API.md
+++ b/REST-API.md
@@ -174,8 +174,8 @@ Returns the metrics from the specified collection.
   * **Code:** `200 (OK)`
   * **Content:** JSON representation of the metrics in the **collection**.
   Example:
-  ```JSON
-  {
+```JSON
+{
   "id" : 0,
   "httpUrls" : {
     "units" : {
@@ -231,7 +231,7 @@ Returns the metrics from the specified collection.
     }
   }
 }
-  ```
+```
 
 * **Error Responses**
 


### PR DESCRIPTION
The rendering of the Markdown within GitHub is broken, such that everything below line 234 wasn't rendering correctly. Removing the spaces fixes the formatting.