### PR TITLE
Support Swift 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,10 @@ matrix:
       osx_image: xcode10.2
       sudo: required
     - os: osx
+      osx_image: xcode11
+      sudo: required
+      env: SWIFT_SNAPSHOT=5.1
+    - os: osx
       osx_image: xcode10.1
       sudo: required
       env: SWIFT_SNAPSHOT=4.2.1 KITURA_NIO=1 BREW_INSTALL_PACKAGES="libressl"

--- a/Sources/SwiftBAMDC/SwiftMetricsBAMConfig.swift
+++ b/Sources/SwiftBAMDC/SwiftMetricsBAMConfig.swift
@@ -26,6 +26,12 @@ import Foundation
 import Dispatch
 import Configuration
 
+#if swift(>=4.1)
+  #if canImport(FoundationNetworking)
+    import FoundationNetworking
+  #endif
+#endif
+
 /*
  #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
  import CommonCrypto

--- a/Sources/SwiftMetricsBluemix/SwiftMetricsBluemix.swift
+++ b/Sources/SwiftMetricsBluemix/SwiftMetricsBluemix.swift
@@ -23,6 +23,12 @@ import SwiftMetrics
 import SwiftMetricsKitura
 import SwiftBAMDC
 
+#if swift(>=4.1)
+  #if canImport(FoundationNetworking)
+    import FoundationNetworking
+  #endif
+#endif
+
 fileprivate struct HttpStats {
   fileprivate var count: Double = 0
   fileprivate var duration: Double = 0

--- a/Tests/SwiftMetricsRESTTests/SwiftMetricsRESTTests.swift
+++ b/Tests/SwiftMetricsRESTTests/SwiftMetricsRESTTests.swift
@@ -20,6 +20,12 @@ import Configuration
 import Foundation
 @testable import SwiftMetricsREST
 
+#if swift(>=4.1)
+  #if canImport(FoundationNetworking)
+    import FoundationNetworking
+  #endif
+#endif
+
 class SwiftMetricsRESTTests: XCTestCase {
 
     let collectionsSubpath = "/swiftmetrics/api/v1/collections"


### PR DESCRIPTION
Due to [changes to Foundation structure](https://forums.swift.org/t/foundationnetworking/24769), we are now required to `import FoundationNetworking` on Linux to access `HTTPCookie` and similar types.

This is guarded by the new `#if canImport` statement which is the recommended way to handle FoundationNetworking (which itself has to be guarded by `#if swift(>=4.1)`, as Swift 4.0 didn't have that).

I also added an `xcode11` Travis build for testing against Swift 5.1.  I haven't added Linux builds as I understand from reading #219 that there are some test issues on Xenial.  This should be added once those are fixed.