### PR TITLE
Add `connectionTimeout` from WebSocketService.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,9 +21,9 @@ import Foundation
 var webSocketPackage: Package.Dependency
 
 if ProcessInfo.processInfo.environment["KITURA_NIO"] != nil {
-    webSocketPackage = .package(url: "https://github.com/IBM-Swift/Kitura-WebSocket-NIO.git", from: "2.0.0")
+    webSocketPackage = .package(url: "https://github.com/Kitura/Kitura-WebSocket-NIO.git", from: "2.1.200")
 } else {
-    webSocketPackage = .package(url: "https://github.com/IBM-Swift/Kitura-WebSocket.git", from: "2.0.0")
+    webSocketPackage = .package(url: "https://github.com/Kitura/Kitura-WebSocket.git", from: "2.1.200")
 }
 
 let package = Package(

--- a/Sources/SwiftMetrics/SwiftMonitor.swift
+++ b/Sources/SwiftMetrics/SwiftMonitor.swift
@@ -217,30 +217,30 @@ public class SwiftMonitor {
     }
   }
 
-  public func on(_ callback: @escaping cpuClosure) {
-    swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing a CPUData observer")
-    EventEmitter.subscribe(callback: callback)
-  }
+  // public func on(_ callback: @escaping cpuClosure) {
+  //   swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing a CPUData observer")
+  //   EventEmitter.subscribe(callback: callback)
+  // }
 
-  public func on(_ callback: @escaping memoryClosure) {
-    swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing a MemData observer")
-    EventEmitter.subscribe(callback: callback)
-  }
+  // public func on(_ callback: @escaping memoryClosure) {
+  //   swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing a MemData observer")
+  //   EventEmitter.subscribe(callback: callback)
+  // }
 
-  public func on(_ callback: @escaping envClosure) {
-    swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing an EnvData observer")
-    EventEmitter.subscribe(callback: callback)
-  }
+  // public func on(_ callback: @escaping envClosure) {
+  //   swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing an EnvData observer")
+  //   EventEmitter.subscribe(callback: callback)
+  // }
 
-  public func on(_ callback: @escaping initClosure) {
-    swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing an InitData observer")
-    EventEmitter.subscribe(callback: callback)
-  }
+  // public func on(_ callback: @escaping initClosure) {
+  //   swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing an InitData observer")
+  //   EventEmitter.subscribe(callback: callback)
+  // }
 
-  public func on(_ callback: @escaping latencyClosure) {
-    swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing a LatencyData observer")
-    EventEmitter.subscribe(callback: callback)
-  }
+  // public func on(_ callback: @escaping latencyClosure) {
+  //   swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing a LatencyData observer")
+  //   EventEmitter.subscribe(callback: callback)
+  // }
 
   public func on<T: SMData>(_ callback: @escaping (T) -> ()) {
     swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing a \(T.self)) observer")

--- a/Sources/SwiftMetrics/SwiftMonitor.swift
+++ b/Sources/SwiftMetrics/SwiftMonitor.swift
@@ -217,30 +217,30 @@ public class SwiftMonitor {
     }
   }
 
-  // public func on(_ callback: @escaping cpuClosure) {
-  //   swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing a CPUData observer")
-  //   EventEmitter.subscribe(callback: callback)
-  // }
+  public func on(_ callback: @escaping cpuClosure) {
+    swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing a CPUData observer")
+    EventEmitter.subscribe(callback: callback)
+  }
 
-  // public func on(_ callback: @escaping memoryClosure) {
-  //   swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing a MemData observer")
-  //   EventEmitter.subscribe(callback: callback)
-  // }
+  public func on(_ callback: @escaping memoryClosure) {
+    swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing a MemData observer")
+    EventEmitter.subscribe(callback: callback)
+  }
 
-  // public func on(_ callback: @escaping envClosure) {
-  //   swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing an EnvData observer")
-  //   EventEmitter.subscribe(callback: callback)
-  // }
+  public func on(_ callback: @escaping envClosure) {
+    swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing an EnvData observer")
+    EventEmitter.subscribe(callback: callback)
+  }
 
-  // public func on(_ callback: @escaping initClosure) {
-  //   swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing an InitData observer")
-  //   EventEmitter.subscribe(callback: callback)
-  // }
+  public func on(_ callback: @escaping initClosure) {
+    swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing an InitData observer")
+    EventEmitter.subscribe(callback: callback)
+  }
 
-  // public func on(_ callback: @escaping latencyClosure) {
-  //   swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing a LatencyData observer")
-  //   EventEmitter.subscribe(callback: callback)
-  // }
+  public func on(_ callback: @escaping latencyClosure) {
+    swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing a LatencyData observer")
+    EventEmitter.subscribe(callback: callback)
+  }
 
   public func on<T: SMData>(_ callback: @escaping (T) -> ()) {
     swiftMetrics.loaderApi.logMessage(fine, "on(): Subscribing a \(T.self)) observer")

--- a/Sources/SwiftMetricsDash/SwiftMetricsDash.swift
+++ b/Sources/SwiftMetricsDash/SwiftMetricsDash.swift
@@ -79,6 +79,7 @@ public class SwiftMetricsDash {
 }
 class SwiftMetricsService: WebSocketService {
 
+    var connectionTimeout: Int? = nil
     private var connections = [String: WebSocketConnection]()
     var httpAggregateData: HTTPAggregateData = HTTPAggregateData()
     var httpURLData:[String:(totalTime:Double, numHits:Double, longestTime:Double)] = [:]


### PR DESCRIPTION
This is required by the new version of the WebSocketService protocol.
Also update dependencies to the community version of Kitura (moved away from IBM-Swift).
This fixes a compilation issue with latest Kitura.